### PR TITLE
Add SAM finetuning script with LoRA and QLoRA options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # finetuning-models-segmentation
-Repositorio para probar finetuning de modelos de segmentacion usando lora/qlora
+
+Repositorio para probar finetuning de modelos de segmentacion usando lora/qlora.
+
+## Uso
+
+El script `finetune.py` permite ajustar modelos tipo SAM2, MedSAM2 y MobileSAM
+sobre los datasets de catarata y retinopatía diabética.
+
+Los datasets deben tener la siguiente estructura:
+
+```
+<root>/
+    images/
+        xxx.png
+    masks/
+        xxx.png
+```
+
+Ejemplo de ejecución:
+
+```
+python finetune.py --model sam2 --method lora --dataset cataract --dataset-root /ruta/al/dataset
+```
+
+El parámetro `--method` acepta `baseline`, `lora` y `qlora` para comparar los
+métodos de entrenamiento.
+
+Los modelos y el procesador resultante se guardan en un directorio con el
+formato `finetuned-<modelo>-<metodo>-<dataset>`.

--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -1,0 +1,12 @@
+from .cataract import build_cataract_dataset
+from .retinopathy import build_retinopathy_dataset
+
+
+def get_dataset(name: str, root: str):
+    """Factory function for available datasets."""
+    name = name.lower()
+    if name == "cataract":
+        return build_cataract_dataset(root)
+    if name in {"retinopathy", "diabetic_retinopathy"}:
+        return build_retinopathy_dataset(root)
+    raise ValueError(f"Unknown dataset: {name}")

--- a/datasets/cataract.py
+++ b/datasets/cataract.py
@@ -1,0 +1,17 @@
+import os
+from .common import SegmentationDataset
+
+def build_cataract_dataset(root: str):
+    """Create a dataset for cataract segmentation.
+
+    Expects the following directory structure inside ``root``::
+
+        root/
+            images/
+                xxx.png
+            masks/
+                xxx.png
+    """
+    image_dir = os.path.join(root, "images")
+    mask_dir = os.path.join(root, "masks")
+    return SegmentationDataset(image_dir, mask_dir)

--- a/datasets/common.py
+++ b/datasets/common.py
@@ -1,0 +1,32 @@
+import os
+from PIL import Image
+from torch.utils.data import Dataset
+from torchvision import transforms as T
+
+class SegmentationDataset(Dataset):
+    """Generic image segmentation dataset.
+
+    Expects two directories: one with images and another with masks.
+    Filenames must match between images and masks.
+    """
+
+    def __init__(self, image_dir: str, mask_dir: str):
+        self.image_dir = image_dir
+        self.mask_dir = mask_dir
+        self.images = sorted(
+            [f for f in os.listdir(image_dir) if f.lower().endswith((".png", ".jpg", ".jpeg", ".tif", ".bmp"))]
+        )
+        self.to_tensor = T.ToTensor()
+
+    def __len__(self) -> int:
+        return len(self.images)
+
+    def __getitem__(self, idx: int):
+        image_name = self.images[idx]
+        img_path = os.path.join(self.image_dir, image_name)
+        mask_path = os.path.join(self.mask_dir, image_name)
+
+        image = Image.open(img_path).convert("RGB")
+        mask = Image.open(mask_path)
+
+        return self.to_tensor(image), self.to_tensor(mask)

--- a/datasets/retinopathy.py
+++ b/datasets/retinopathy.py
@@ -1,0 +1,11 @@
+import os
+from .common import SegmentationDataset
+
+def build_retinopathy_dataset(root: str):
+    """Create a dataset for diabetic retinopathy segmentation.
+
+    Expects the same folder layout as :func:`build_cataract_dataset`.
+    """
+    image_dir = os.path.join(root, "images")
+    mask_dir = os.path.join(root, "masks")
+    return SegmentationDataset(image_dir, mask_dir)

--- a/finetune.py
+++ b/finetune.py
@@ -1,0 +1,85 @@
+import argparse
+import torch
+from torch.utils.data import DataLoader
+from datasets import get_dataset
+from transformers import SamModel, SamProcessor
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+
+MODEL_IDS = {
+    "sam2": "facebook/sam2-hiera-small",
+    "medsam2": "facebook/medsam2-hiera-small",
+    "mobilesam": "facebook/mobile-sam",
+}
+
+def create_model(model_key: str, method: str) -> SamModel:
+    model_id = MODEL_IDS[model_key]
+    if method == "qlora":
+        model = SamModel.from_pretrained(
+            model_id,
+            device_map="auto",
+            load_in_4bit=True,
+            torch_dtype=torch.float16,
+        )
+        model = prepare_model_for_kbit_training(model)
+        peft_config = LoraConfig(
+            r=8,
+            lora_alpha=16,
+            target_modules=["q_proj", "k_proj", "v_proj"],
+            lora_dropout=0.05,
+            bias="none",
+            task_type="VISION",
+        )
+        model = get_peft_model(model, peft_config)
+    elif method == "lora":
+        model = SamModel.from_pretrained(model_id)
+        peft_config = LoraConfig(
+            r=8,
+            lora_alpha=16,
+            target_modules=["q_proj", "k_proj", "v_proj"],
+            lora_dropout=0.05,
+            bias="none",
+            task_type="VISION",
+        )
+        model = get_peft_model(model, peft_config)
+    else:
+        model = SamModel.from_pretrained(model_id)
+    return model
+
+def main():
+    parser = argparse.ArgumentParser(description="Fine-tune SAM-based models on medical datasets.")
+    parser.add_argument("--model", choices=list(MODEL_IDS.keys()), required=True)
+    parser.add_argument("--method", choices=["baseline", "lora", "qlora"], default="baseline")
+    parser.add_argument("--dataset", choices=["cataract", "retinopathy"], required=True)
+    parser.add_argument("--dataset-root", required=True)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = create_model(args.model, args.method)
+    model.to(device)
+
+    processor = SamProcessor.from_pretrained(MODEL_IDS[args.model])
+    dataset = get_dataset(args.dataset, args.dataset_root)
+    dataloader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
+
+    model.train()
+    for epoch in range(args.epochs):
+        for images, masks in dataloader:
+            inputs = processor(images=list(images), segmentation_maps=list(masks), return_tensors="pt").to(device)
+            outputs = model(**inputs)
+            loss = outputs.loss
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+        print(f"Epoch {epoch + 1}: loss={loss.item():.4f}")
+
+    save_dir = f"finetuned-{args.model}-{args.method}-{args.dataset}"
+    model.save_pretrained(save_dir)
+    processor.save_pretrained(save_dir)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+torch
+torchvision
+transformers
+peft
+bitsandbytes
+Pillow


### PR DESCRIPTION
## Summary
- add generic dataset loaders for cataract and diabetic retinopathy segmentation
- implement `finetune.py` script supporting SAM2, MedSAM2 and MobileSAM with baseline, LoRA and QLoRA training
- document usage and expected dataset structure

## Testing
- `python -m py_compile finetune.py datasets/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8ccac91f48320822c4f315dbb137a