### PR TITLE
feat: add COCO dataset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Repositorio para probar finetuning de modelos de segmentacion usando lora/qlora.
 El script `finetune.py` permite ajustar modelos tipo SAM2, MedSAM2 y MobileSAM
 sobre los datasets de catarata y retinopatía diabética.
 
-Los datasets deben tener la siguiente estructura:
+Los datasets pueden estar organizados de dos maneras:
+
+1. Directorios separados de imágenes y máscaras binaras:
 
 ```
 <root>/
@@ -16,6 +18,23 @@ Los datasets deben tener la siguiente estructura:
     masks/
         xxx.png
 ```
+
+2. Formato COCO (por ejemplo exportado desde Roboflow), donde cada división
+contiene todas las imágenes y un archivo `_annotations.coco.json`:
+
+```
+<root>/
+    train/
+        _annotations.coco.json
+        img1.png
+        ...
+    valid/
+        _annotations.coco.json
+        ...
+```
+
+En este caso, proporcione la ruta del subconjunto deseado (`train`, `valid`,
+etc.) mediante el parámetro `--dataset-root`.
 
 Ejemplo de ejecución:
 

--- a/datasets/cataract.py
+++ b/datasets/cataract.py
@@ -1,5 +1,5 @@
 import os
-from .common import SegmentationDataset
+from .common import SegmentationDataset, CocoSegmentationDataset
 
 def build_cataract_dataset(root: str):
     """Create a dataset for cataract segmentation.
@@ -12,6 +12,9 @@ def build_cataract_dataset(root: str):
             masks/
                 xxx.png
     """
+    ann_file = os.path.join(root, "_annotations.coco.json")
+    if os.path.exists(ann_file):
+        return CocoSegmentationDataset(root)
     image_dir = os.path.join(root, "images")
     mask_dir = os.path.join(root, "masks")
     return SegmentationDataset(image_dir, mask_dir)

--- a/datasets/common.py
+++ b/datasets/common.py
@@ -1,7 +1,13 @@
 import os
+import numpy as np
 from PIL import Image
 from torch.utils.data import Dataset
 from torchvision import transforms as T
+
+try:
+    from pycocotools.coco import COCO
+except Exception:  # pragma: no cover - optional dependency
+    COCO = None
 
 class SegmentationDataset(Dataset):
     """Generic image segmentation dataset.
@@ -30,3 +36,42 @@ class SegmentationDataset(Dataset):
         mask = Image.open(mask_path)
 
         return self.to_tensor(image), self.to_tensor(mask)
+
+
+class CocoSegmentationDataset(Dataset):
+    """Dataset for images annotated in COCO segmentation format.
+
+    Parameters
+    ----------
+    root: str
+        Directory containing the images and a ``_annotations.coco.json`` file.
+    ann_file: str, optional
+        Name of the annotations file relative to ``root``.
+    """
+
+    def __init__(self, root: str, ann_file: str = "_annotations.coco.json"):
+        if COCO is None:
+            raise ImportError("pycocotools is required for CocoSegmentationDataset")
+        self.root = root
+        ann_path = os.path.join(root, ann_file)
+        self.coco = COCO(ann_path)
+        self.img_ids = list(sorted(self.coco.imgs.keys()))
+        self.to_tensor = T.ToTensor()
+
+    def __len__(self) -> int:  # pragma: no cover - simple delegation
+        return len(self.img_ids)
+
+    def __getitem__(self, idx: int):
+        img_id = self.img_ids[idx]
+        img_info = self.coco.loadImgs([img_id])[0]
+        image_path = os.path.join(self.root, img_info["file_name"])
+        image = Image.open(image_path).convert("RGB")
+
+        ann_ids = self.coco.getAnnIds(imgIds=[img_id])
+        anns = self.coco.loadAnns(ann_ids)
+        mask = np.zeros((img_info["height"], img_info["width"]), dtype=np.uint8)
+        for ann in anns:
+            ann_mask = self.coco.annToMask(ann)
+            mask = np.maximum(mask, ann_mask)
+        mask_img = Image.fromarray(mask * 255)
+        return self.to_tensor(image), self.to_tensor(mask_img)

--- a/datasets/retinopathy.py
+++ b/datasets/retinopathy.py
@@ -1,11 +1,14 @@
 import os
-from .common import SegmentationDataset
+from .common import SegmentationDataset, CocoSegmentationDataset
 
 def build_retinopathy_dataset(root: str):
     """Create a dataset for diabetic retinopathy segmentation.
 
     Expects the same folder layout as :func:`build_cataract_dataset`.
     """
+    ann_file = os.path.join(root, "_annotations.coco.json")
+    if os.path.exists(ann_file):
+        return CocoSegmentationDataset(root)
     image_dir = os.path.join(root, "images")
     mask_dir = os.path.join(root, "masks")
     return SegmentationDataset(image_dir, mask_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ transformers
 peft
 bitsandbytes
 Pillow
+pycocotools


### PR DESCRIPTION
## Summary
- add COCO-compatible dataset loader
- enable cataract and retinopathy datasets in COCO format
- document COCO dataset layout

## Testing
- `python -m py_compile datasets/common.py datasets/cataract.py datasets/retinopathy.py finetune.py`
- `python - <<'PY'
from datasets import get_dataset
import torch

path='data/Cataract COCO Segmentation/train'

ds=get_dataset('cataract', path)
print('len', len(ds))
img, mask=ds[0]
print('img', img.shape, 'mask', mask.shape, 'max', torch.max(mask))
PY` *(failed: ModuleNotFoundError: No module named 'torch')*
- `python - <<'PY'
import torch, torchvision
print(torch.__version__, torchvision.__version__)
PY` *(failed: OSError: libtorch_global_deps.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d132da5883209aa2c1e5b5c93c03