### PR TITLE
Add SAM model manager for downloading checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,22 @@ métodos de entrenamiento.
 
 Los modelos y el procesador resultante se guardan en un directorio con el
 formato `finetuned-<modelo>-<metodo>-<dataset>`.
+
+## Gestión de modelos
+
+Para descargar e instalar los pesos oficiales de las distintas variantes de
+SAM, MobileSAM, HQ-SAM y MedSAM(+2) se incluye el módulo
+`model_manager.py`. Este expone la clase `SAMModelManager`, que automatiza la
+instalación de los repositorios y la obtención de los checkpoints.
+
+Ejemplo de uso:
+
+```python
+from model_manager import SAMModelManager
+
+mgr = SAMModelManager("Models")
+ckpt_path = mgr.setup("mobilesam", "vit_t")
+```
+
+Los archivos descargados se guardarán dentro del directorio indicado (en el
+ejemplo, `Models`).

--- a/model_manager.py
+++ b/model_manager.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+import subprocess
+import sys
+import re
+from huggingface_hub import hf_hub_download
+
+
+class SAMModelManager:
+    """Gestor unificado para SAM, MobileSAM, HQ-SAM/Light-HQ-SAM y MedSAM(+2)."""
+
+    _MODELS = {
+        # 1) Segment Anything original ---------------------------------------
+        "sam": {
+            "pip": "git+https://github.com/facebookresearch/segment-anything.git",
+            "variants": {
+                "vit_b": ("url", "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth"),
+                "vit_l": ("url", "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth"),
+                "vit_h": ("url", "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"),
+            },
+        },
+        # 2) MobileSAM --------------------------------------------------------
+        #   *Peso oficial en HF: repo «dhkim2810/MobileSAM», archivo mobile_sam.pt*
+        "mobilesam": {
+            "pip": "git+https://github.com/ChaoningZhang/MobileSAM.git",
+            "variants": {
+                "vit_t": ("dhkim2810/MobileSAM", "mobile_sam.pt"),  # 40 MB
+            },
+        },
+        # 3) HQ-SAM / Light-HQ-SAM -------------------------------------------
+        "hq_sam": {
+            "pip": "git+https://github.com/SysCV/sam-hq.git",
+            "variants": {
+                "vit_l": ("url", "https://huggingface.co/lkeab/hq-sam/resolve/main/sam_hq_vit_l.pth"),
+                "vit_t": ("url", "https://huggingface.co/lkeab/hq-sam/resolve/main/sam_hq_vit_tiny.pth"),
+                "vit_h": ("url", "https://huggingface.co/lkeab/hq-sam/resolve/main/sam_hq_vit_h.pth"),
+                "vit_b": ("url", "https://huggingface.co/lkeab/hq-sam/resolve/main/sam_hq_vit_b.pth"),
+                "hiera_l_2.1": ("url", "https://huggingface.co/lkeab/hq-sam/resolve/main/sam2.1_hq_hiera_large.pt"),
+            },
+        },
+        # 4) MedSAM y MedSAM2 -------------------------------------------------
+        "medsam": {
+            "pip": "git+https://github.com/bowang-lab/MedSAM.git",
+            "variants": {
+                "medsam1": ("url", "https://zenodo.org/records/10689643/files/medsam_vit_b.pth"),
+                "medsam2_latest": ("url", "https://huggingface.co/wanglab/MedSAM2/resolve/main/MedSAM2_latest.pt"),
+            },
+        },
+    }
+
+    def __init__(self, root_dir: str):
+        self.root = Path(root_dir).expanduser()
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    # ---------------------------- API pública ------------------------------
+    def install_repo(self, family: str) -> None:
+        pkg = self._MODELS[family]["pip"]
+        if not self._pkg_installed(pkg):
+            print(f"Instalando {family}…")
+            subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+        else:
+            print(f"{family} ya estaba instalado.")
+
+    def download_variant(self, family: str, variant: str, force: bool = False) -> Path:
+        repo_or_url, filename = self._MODELS[family]["variants"][variant]
+        dest = self.root / Path(filename).name
+
+        if dest.exists() and not force:
+            print(f"{dest.name} ya existe → se omite descarga.")
+            return dest
+
+        if repo_or_url == "url" or repo_or_url.startswith("http"):
+            import requests
+
+            url = filename if repo_or_url == "url" else repo_or_url
+            print(f"Descargando desde URL directa:\n  {url}")
+            with requests.get(url, stream=True) as r:
+                r.raise_for_status()
+                with open(dest, "wb") as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        f.write(chunk)
+        else:
+            print(f"Descargando desde Hugging Face ({repo_or_url})…")
+            dest_path = hf_hub_download(
+                repo_id=repo_or_url,
+                filename=filename,
+                cache_dir=str(self.root),
+                force_download=force,
+            )
+            dest = Path(dest_path)
+
+        return dest
+
+    def setup(self, family: str, variant: str, install: bool = True, force: bool = False) -> Path:
+        if install:
+            self.install_repo(family)
+        return self.download_variant(family, variant, force)
+
+    def list_supported(self) -> None:
+        for fam, info in self._MODELS.items():
+            print(f"{fam}: {', '.join(info['variants'])}")
+
+    @staticmethod
+    def _pkg_installed(pip_spec: str) -> bool:
+        import pkg_resources
+
+        name = re.sub(r".*/|\.git$", "", pip_spec)
+        try:
+            pkg_resources.get_distribution(name)
+            return True
+        except pkg_resources.DistributionNotFound:
+            return False
+
+
+if __name__ == "__main__":  # pragma: no cover - ejemplo de uso
+    mgr = SAMModelManager("Models")
+    mgr.list_supported()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ peft
 bitsandbytes
 Pillow
 pycocotools
+huggingface_hub
+requests


### PR DESCRIPTION
## Summary
- add `SAMModelManager` utility for installing repos and fetching SAM-family weights
- document usage of the manager in README
- include missing dependencies in requirements

## Testing
- `python -m py_compile model_manager.py finetune.py datasets/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8d48d16c8832084e9420a3159b1a3