### PR TITLE
Establece dtype tras carga de modelo

### DIFF
--- a/models/medsam2_model.py
+++ b/models/medsam2_model.py
@@ -37,12 +37,13 @@ class MedSAM2Model(BaseSegmentationModel):
     def load_model(self) -> None:
         """Carga el modelo MedSAM2 desde Hugging Face."""
         try:
+            dtype = torch.float16 if torch.cuda.is_available() else torch.float32
             # Intentar cargar como SamModel primero
             try:
                 self.model = SamModel.from_pretrained(
                     self.model_name,
                     cache_dir=self.cache_dir,
-                    torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32
+                    torch_dtype=dtype
                 )
             except Exception:
                 # Fallback: cargar como AutoModel genérico
@@ -50,9 +51,9 @@ class MedSAM2Model(BaseSegmentationModel):
                     self.model_name,
                     cache_dir=self.cache_dir,
                     trust_remote_code=True,
-                    torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32
+                    torch_dtype=dtype
                 )
-            
+            self.dtype = dtype
             print(f"✅ Modelo MedSAM2 ({self.variant}) cargado desde: {self.model_name}")
         except Exception as e:
             raise RuntimeError(f"Error cargando modelo MedSAM2: {e}")

--- a/models/mobilesam_model.py
+++ b/models/mobilesam_model.py
@@ -38,12 +38,13 @@ class MobileSAMModel(BaseSegmentationModel):
     def load_model(self) -> None:
         """Carga el modelo MobileSAM desde Hugging Face."""
         try:
+            dtype = torch.float16 if torch.cuda.is_available() else torch.float32
             # Intentar cargar como SamModel primero
             try:
                 self.model = SamModel.from_pretrained(
                     self.model_name,
                     cache_dir=self.cache_dir,
-                    torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32
+                    torch_dtype=dtype
                 )
             except Exception:
                 # Fallback: cargar como AutoModel genérico
@@ -51,9 +52,9 @@ class MobileSAMModel(BaseSegmentationModel):
                     self.model_name,
                     cache_dir=self.cache_dir,
                     trust_remote_code=True,
-                    torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32
+                    torch_dtype=dtype
                 )
-            
+            self.dtype = dtype
             print(f"✅ Modelo MobileSAM ({self.variant}) cargado desde: {self.model_name}")
         except Exception as e:
             raise RuntimeError(f"Error cargando modelo MobileSAM: {e}")


### PR DESCRIPTION
## Summary
- Asigna `self.dtype` basado en disponibilidad de CUDA tras cargar el modelo MedSAM2
- Asigna `self.dtype` apropiado tras cargar el modelo MobileSAM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5377fa2488320b8ea79a7239bf7ff