### PR TITLE
refactor: centralize arg filtering

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -179,11 +179,38 @@ class BaseSegmentationModel(ABC):
     def _get_default_lora_targets(self) -> list:
         """Retorna los módulos objetivo por defecto para LoRA."""
         pass
-        
+
+    def _filter_conflicting_args(self, inputs):
+        """
+        Filtra argumentos que causan conflictos específicos.
+        Solo se llama cuando se detecta un conflicto real.
+        """
+        # Argumentos esenciales que siempre se mantienen
+        essential_args = ['pixel_values', 'original_sizes', 'reshaped_input_sizes']
+        # Argumentos problemáticos que se filtran
+        problematic_args = ['attention_mask', 'position_ids']
+
+        # Si inputs es un objeto con atributos, extraer como diccionario
+        if hasattr(inputs, '__dict__'):
+            input_dict = {}
+            for key in dir(inputs):
+                if not key.startswith('_') and not callable(getattr(inputs, key)):
+                    input_dict[key] = getattr(inputs, key)
+        else:
+            input_dict = dict(inputs)
+
+        # Filtrar argumentos problemáticos
+        filtered_dict = {}
+        for key, value in input_dict.items():
+            if key in essential_args or key not in problematic_args:
+                filtered_dict[key] = value
+
+        return filtered_dict
+
     def get_trainable_parameters(self) -> Tuple[int, int]:
         """
         Retorna el número de parámetros entrenables y totales.
-        
+
         Returns:
             Tuple con (parámetros_entrenables, parámetros_totales)
         """

--- a/models/medsam2_model.py
+++ b/models/medsam2_model.py
@@ -132,12 +132,12 @@ class MedSAM2Model(BaseSegmentationModel):
                 if "multiple values" in str(e) and "attention_mask" in str(e):
                     # Solo filtrar si hay conflicto confirmado de attention_mask
                     print("⚠️  Detectado conflicto de attention_mask, aplicando filtrado...")
-                    filtered_inputs = self._filter_conflicting_args(inputs)
+                    filtered_inputs = super()._filter_conflicting_args(inputs)
                     return self.model(**filtered_inputs)
                 elif "multiple values" in str(e) and "position_ids" in str(e):
                     # Solo filtrar si hay conflicto confirmado de position_ids
                     print("⚠️  Detectado conflicto de position_ids, aplicando filtrado...")
-                    filtered_inputs = self._filter_conflicting_args(inputs)
+                    filtered_inputs = super()._filter_conflicting_args(inputs)
                     return self.model(**filtered_inputs)
                 else:
                     # Re-raise otros errores de tipo
@@ -148,33 +148,6 @@ class MedSAM2Model(BaseSegmentationModel):
                 images = images.to(self.device).to(model_dtype)
             return self.model(pixel_values=images)
     
-    def _filter_conflicting_args(self, inputs):
-        """
-        Filtra argumentos que causan conflictos específicos.
-        Solo se llama cuando se detecta un conflicto real.
-        """
-        # Argumentos esenciales que siempre se mantienen
-        essential_args = ['pixel_values', 'original_sizes', 'reshaped_input_sizes']
-        # Argumentos problemáticos que se filtran
-        problematic_args = ['attention_mask', 'position_ids']
-        
-        # Si inputs es un objeto con atributos, extraer como diccionario
-        if hasattr(inputs, '__dict__'):
-            input_dict = {}
-            for key in dir(inputs):
-                if not key.startswith('_') and not callable(getattr(inputs, key)):
-                    input_dict[key] = getattr(inputs, key)
-        else:
-            input_dict = dict(inputs)
-        
-        # Filtrar argumentos problemáticos
-        filtered_dict = {}
-        for key, value in input_dict.items():
-            if key in essential_args or key not in problematic_args:
-                filtered_dict[key] = value
-                
-        return filtered_dict
-                
     @classmethod
     def list_available_variants(cls) -> dict:
         """Lista las variantes disponibles del modelo."""

--- a/models/mobilesam_model.py
+++ b/models/mobilesam_model.py
@@ -132,12 +132,12 @@ class MobileSAMModel(BaseSegmentationModel):
                 if "multiple values" in str(e) and "attention_mask" in str(e):
                     # Solo filtrar si hay conflicto confirmado de attention_mask
                     print("⚠️  Detectado conflicto de attention_mask, aplicando filtrado...")
-                    filtered_inputs = self._filter_conflicting_args(inputs)
+                    filtered_inputs = super()._filter_conflicting_args(inputs)
                     return self.model(**filtered_inputs)
                 elif "multiple values" in str(e) and "position_ids" in str(e):
                     # Solo filtrar si hay conflicto confirmado de position_ids
                     print("⚠️  Detectado conflicto de position_ids, aplicando filtrado...")
-                    filtered_inputs = self._filter_conflicting_args(inputs)
+                    filtered_inputs = super()._filter_conflicting_args(inputs)
                     return self.model(**filtered_inputs)
                 else:
                     # Re-raise otros errores de tipo
@@ -148,33 +148,6 @@ class MobileSAMModel(BaseSegmentationModel):
                 images = images.to(self.device).to(model_dtype)
             return self.model(pixel_values=images)
     
-    def _filter_conflicting_args(self, inputs):
-        """
-        Filtra argumentos que causan conflictos específicos.
-        Solo se llama cuando se detecta un conflicto real.
-        """
-        # Argumentos esenciales que siempre se mantienen
-        essential_args = ['pixel_values', 'original_sizes', 'reshaped_input_sizes']
-        # Argumentos problemáticos que se filtran
-        problematic_args = ['attention_mask', 'position_ids']
-        
-        # Si inputs es un objeto con atributos, extraer como diccionario
-        if hasattr(inputs, '__dict__'):
-            input_dict = {}
-            for key in dir(inputs):
-                if not key.startswith('_') and not callable(getattr(inputs, key)):
-                    input_dict[key] = getattr(inputs, key)
-        else:
-            input_dict = dict(inputs)
-        
-        # Filtrar argumentos problemáticos
-        filtered_dict = {}
-        for key, value in input_dict.items():
-            if key in essential_args or key not in problematic_args:
-                filtered_dict[key] = value
-                
-        return filtered_dict
-                
     def optimize_for_mobile(self) -> None:
         """Optimizaciones específicas para dispositivos móviles."""
         if self.model is None:

--- a/models/sam2_model.py
+++ b/models/sam2_model.py
@@ -121,12 +121,12 @@ class SAM2Model(BaseSegmentationModel):
                 if "multiple values" in str(e) and "attention_mask" in str(e):
                     # Solo filtrar si hay conflicto confirmado de attention_mask
                     print("⚠️  Detectado conflicto de attention_mask, aplicando filtrado...")
-                    filtered_inputs = self._filter_conflicting_args(inputs)
+                    filtered_inputs = super()._filter_conflicting_args(inputs)
                     return self.model(**filtered_inputs)
                 elif "multiple values" in str(e) and "position_ids" in str(e):
                     # Solo filtrar si hay conflicto confirmado de position_ids
                     print("⚠️  Detectado conflicto de position_ids, aplicando filtrado...")
-                    filtered_inputs = self._filter_conflicting_args(inputs)
+                    filtered_inputs = super()._filter_conflicting_args(inputs)
                     return self.model(**filtered_inputs)
                 else:
                     # Re-raise otros errores de tipo
@@ -136,33 +136,6 @@ class SAM2Model(BaseSegmentationModel):
             if hasattr(images, 'to'):
                 images = images.to(self.device).to(model_dtype)
             return self.model(pixel_values=images)
-            
-    def _filter_conflicting_args(self, inputs):
-        """
-        Filtra argumentos que causan conflictos específicos.
-        Solo se llama cuando se detecta un conflicto real.
-        """
-        # Argumentos esenciales que siempre se mantienen
-        essential_args = ['pixel_values', 'original_sizes', 'reshaped_input_sizes']
-        # Argumentos problemáticos que se filtran
-        problematic_args = ['attention_mask', 'position_ids']
-        
-        # Si inputs es un objeto con atributos, extraer como diccionario
-        if hasattr(inputs, '__dict__'):
-            input_dict = {}
-            for key in dir(inputs):
-                if not key.startswith('_') and not callable(getattr(inputs, key)):
-                    input_dict[key] = getattr(inputs, key)
-        else:
-            input_dict = dict(inputs)
-        
-        # Filtrar argumentos problemáticos
-        filtered_dict = {}
-        for key, value in input_dict.items():
-            if key in essential_args or key not in problematic_args:
-                filtered_dict[key] = value
-                
-        return filtered_dict
             
     @classmethod
     def list_available_variants(cls) -> dict:


### PR DESCRIPTION
## Summary
- move `_filter_conflicting_args` to `BaseSegmentationModel`
- remove duplicated implementations in specific SAM models
- update forward methods to call the base helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b549246bf88320bffca3a0e22d4703